### PR TITLE
Change tier-name font from Merriweather to Avenir

### DIFF
--- a/sass/mbb.scss
+++ b/sass/mbb.scss
@@ -180,6 +180,7 @@ body.background {
       opacity: 1;
       transition: opacity ease $slow;
       color: $offwhite;
+      font-family: $font-big;
       font-size: 36px;
       z-index: 2;
 


### PR DESCRIPTION
Merriweather is the subtitle font and Avenir is the Header font. Makes more sense to have the header font for Tier names (we talked about this last tier meeting).
